### PR TITLE
Configure flask network interface

### DIFF
--- a/home.py
+++ b/home.py
@@ -3,6 +3,7 @@ from flask import Flask, render_template, request
 import nobles_management_beta
 import misc_tools
 import json
+import sys
 
 app = Flask(__name__)
 NobleManager = nobles_management_beta.NobleManager()
@@ -70,4 +71,9 @@ def get_song():
     return request.form["url"]
 
 if __name__ == "__main__":
-    app.run()
+	bind = sys.argv[1]
+
+	if not bind:
+		bind = "127.0.0.1"
+
+	app.run(host=bind)

--- a/home.py
+++ b/home.py
@@ -71,9 +71,9 @@ def get_song():
     return request.form["url"]
 
 if __name__ == "__main__":
-	bind = sys.argv[1]
-
-	if not bind:
-		bind = "127.0.0.1"
+	bind = "127.0.0.1"
+	
+	if len(sys.argv) == 2:
+		bind = sys.argv[1]
 
 	app.run(host=bind)


### PR DESCRIPTION
`home.py` runs on localhost by default but by providing a first argument, one can change the location.  E.g.

```
$ python home.py 192.168.0.1
```
